### PR TITLE
Implementing ScamScreener to Wizard and Fixed persistence of background image

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     modImplementation("com.daqem.uilib:uilib-fabric:${property("deps.uilib_version")}")
 
     modImplementation("maven.modrinth:modmenu:${property("deps.modmenu_version")}")
+    modCompileOnly("maven.modrinth:scamscreener:${property("deps.scamscreener_version")}")
 
     modImplementation("net.azureaaron:hm-api:${property("deps.hm_api_version")}")
     include("net.azureaaron:hm-api:${property("deps.hm_api_version")}")
@@ -42,6 +43,8 @@ dependencies {
 
     modRuntimeOnly("me.djtheredstoner:DevAuth-fabric:1.2.2")
     modRuntimeOnly("maven.modrinth:modmenu:${property("deps.modmenu_version")}")
+
+    modRuntimeOnly("maven.modrinth:scamscreener:${property("deps.scamscreener_version")}")
 }
 
 loom {
@@ -140,6 +143,9 @@ publishMods {
         }
         optional {
             slug = "mOgUt4GM" // ModMenu
+        }
+        optional {
+            slug = "scamscreener"
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ deps.moulconfig_version=[VERSIONED]
 deps.midnightlib_version=[VERSIONED]
 deps.hm_api_version=[VERSIONED]
 deps.modmenu_version=[VERSIONED]
+deps.scamscreener_version=[VERSIONED]
 
 deps.sodium_version=[VERSIONED]
 deps.iris_version=[VERSIONED]

--- a/src/main/java/com/github/kd_gaming1/packcore/gui/component/MarkdownComponent.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/gui/component/MarkdownComponent.java
@@ -83,7 +83,7 @@ public class MarkdownComponent extends AbstractComponent {
 
     public MarkdownComponent(int x, int y, int maxWidth, String markdown, int defaultColor) {
         super(x, y, maxWidth, 0);
-        this.markdown = markdown;
+        this.markdown = markdown != null ? markdown : "";
         this.maxWidth = maxWidth;
         this.defaultColor = defaultColor;
         rebuild();

--- a/src/main/java/com/github/kd_gaming1/packcore/gui/screen/SBETitleScreen.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/gui/screen/SBETitleScreen.java
@@ -139,11 +139,12 @@ public class SBETitleScreen extends AbstractScreen {
         int overlayX = (this.width - overlayW) / 2;
         int overlayY = (this.height - overlayH) / 2 + 25;
 
-        String changelogMarkdown = updateStatus.changelog();
+        String changelogVersion = resolveChangelogVersion(updateStatus);
+        String changelogMarkdown = resolveChangelogMarkdown(updateStatus);
 
         changelogOverlay = new OverlayComponent(
                 overlayX, overlayY, overlayW, overlayH,
-                Component.translatable("gui.packcore.overlay.changelog.title", updateStatus.latestVersion()),
+                Component.translatable("gui.packcore.overlay.changelog.title", changelogVersion),
                 changelogMarkdown
         );
         changelogOverlay.setOnClose(() -> setMenuButtonsVisible(true));
@@ -356,6 +357,26 @@ public class SBETitleScreen extends AbstractScreen {
         }
 
         return Component.literal("v" + installed);
+    }
+
+    private static String resolveChangelogVersion(UpdateStatus status) {
+        if (status.latestVersion() != null && !status.latestVersion().isBlank()) {
+            return status.latestVersion();
+        }
+        if (status.installedVersion() != null && !status.installedVersion().isBlank()) {
+            return status.installedVersion();
+        }
+        return ModpackMetadata.getInstance().getModpackVersion();
+    }
+
+    private static String resolveChangelogMarkdown(UpdateStatus status) {
+        if (status.changelog() != null && !status.changelog().isBlank()) {
+            return status.changelog();
+        }
+
+        return Component.translatable("gui.packcore.overlay.changelog.empty").getString()
+                + "\n\n"
+                + Component.translatable("gui.packcore.overlay.changelog.empty.hint").getString();
     }
 
     private void setMenuButtonsVisible(boolean visible) {

--- a/src/main/java/com/github/kd_gaming1/packcore/gui/screen/WelcomeWizardScreen.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/gui/screen/WelcomeWizardScreen.java
@@ -63,6 +63,7 @@ public class WelcomeWizardScreen extends AbstractScreen {
         navigator.addPage(new TabDesignPage(wizardState, navigator, contentWidth, contentHeight));
         navigator.addPage(new ItemBackgroundPage(wizardState, navigator, contentWidth, contentHeight));
         navigator.addPage(new StorageDesignPage(wizardState, navigator, contentWidth, contentHeight));
+        navigator.addPage(new ScamScreenerPage(wizardState, navigator, contentWidth, contentHeight));
         navigator.addPage(new ResourcePackPage(wizardState, navigator, contentWidth, contentHeight));
 
         confirmApplyPage = new ConfirmApplyPage(wizardState, navigator, contentWidth, contentHeight);

--- a/src/main/java/com/github/kd_gaming1/packcore/gui/screen/WelcomeWizardScreen.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/gui/screen/WelcomeWizardScreen.java
@@ -8,6 +8,7 @@ import com.github.kd_gaming1.packcore.gui.wizard.page.*;
 import com.github.kd_gaming1.packcore.metadata.ModpackMetadata;
 import eu.midnightdust.lib.config.MidnightConfig;
 import com.github.kd_gaming1.packcore.gui.wizard.page.ConfirmApplyPage;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
@@ -63,7 +64,9 @@ public class WelcomeWizardScreen extends AbstractScreen {
         navigator.addPage(new TabDesignPage(wizardState, navigator, contentWidth, contentHeight));
         navigator.addPage(new ItemBackgroundPage(wizardState, navigator, contentWidth, contentHeight));
         navigator.addPage(new StorageDesignPage(wizardState, navigator, contentWidth, contentHeight));
-        navigator.addPage(new ScamScreenerPage(wizardState, navigator, contentWidth, contentHeight));
+        if (FabricLoader.getInstance().isModLoaded("scamscreener")) {
+            navigator.addPage(new ScamScreenerPage(wizardState, navigator, contentWidth, contentHeight));
+        }
         navigator.addPage(new ResourcePackPage(wizardState, navigator, contentWidth, contentHeight));
 
         confirmApplyPage = new ConfirmApplyPage(wizardState, navigator, contentWidth, contentHeight);

--- a/src/main/java/com/github/kd_gaming1/packcore/gui/screen/WelcomeWizardScreen.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/gui/screen/WelcomeWizardScreen.java
@@ -113,7 +113,7 @@ public class WelcomeWizardScreen extends AbstractScreen {
         // Finish — settings have been applied; mark complete and close
         buttonBar.setOnFinish(() -> {
             markWizardComplete();
-            Minecraft.getInstance().setScreen(lastScreen);
+            Minecraft.getInstance().setScreen(resolvePostWizardScreen());
         });
 
         // Skip on the last page — close without applying; still marks complete
@@ -132,6 +132,14 @@ public class WelcomeWizardScreen extends AbstractScreen {
     private void markWizardComplete() {
         PackCoreConfig.successfulWelcomeWizard = true;
         MidnightConfig.write(MOD_ID);
+    }
+
+    private Screen resolvePostWizardScreen() {
+        return switch (PackCoreConfig.menuStyle) {
+            case MODERN -> new SBETitleScreen();
+            case MODERN_MINIMAL -> new SBETitleScreen(false);
+            case MINIMAL -> new PackCoreTitleScreen();
+        };
     }
 
     @Override

--- a/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/WizardButtonBar.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/WizardButtonBar.java
@@ -33,10 +33,10 @@ public class WizardButtonBar extends EmptyComponent {
             Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/disabled_continue_gray_button"),
             Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/hover_continue_gray_button")
     );
-    private static final WidgetSprites PRIMARY_CONTINUE_BUTTON = new WidgetSprites(
-            Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/blank_red_button"),
-            Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/disabled_red_button"),
-            Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/hover_red_button")
+    private static final WidgetSprites SCAM_SCREENER_CONTINUE_BUTTON = new WidgetSprites(
+            Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/continue_gray_button"),
+            Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/continue_gray_button"),
+            Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/hover_continue_gray_button")
     );
 
     private static final WidgetSprites PREVIOUS_BUTTON = new WidgetSprites(
@@ -70,7 +70,7 @@ public class WizardButtonBar extends EmptyComponent {
     private final ButtonWidget backButton;
     private final ButtonWidget skipButton;
     private final ButtonWidget continueButton;
-    private final ButtonWidget primaryContinueButton;
+    private final ButtonWidget scamScreenerContinueButton;
     private final ButtonWidget finishButton;
 
     public WizardButtonBar(WizardNavigator navigator, int width, int height) {
@@ -106,10 +106,10 @@ public class WizardButtonBar extends EmptyComponent {
                 CONTINUE_BUTTON,
                 btn -> navigator.nextPage()
         );
-        primaryContinueButton = new CustomButtonWidget(
+        scamScreenerContinueButton = new CustomButtonWidget(
                 width - BTN_WIDTH - BTN_GAP, btnY, BTN_WIDTH, BTN_HEIGHT,
                 Component.translatable("gui.packcore.wizard.button.continue"),
-                PRIMARY_CONTINUE_BUTTON,
+                SCAM_SCREENER_CONTINUE_BUTTON,
                 btn -> navigator.nextPage()
         );
 
@@ -145,7 +145,7 @@ public class WizardButtonBar extends EmptyComponent {
         this.addWidget(skipButton);
         this.addWidget(backButton);
         this.addWidget(continueButton);
-        this.addWidget(primaryContinueButton);
+        this.addWidget(scamScreenerContinueButton);
         this.addWidget(finishButton);
 
         refresh();
@@ -155,16 +155,16 @@ public class WizardButtonBar extends EmptyComponent {
     public void refresh() {
         boolean hasBack = navigator.hasPrevious();
         boolean isLastPage = navigator.isOnLastPage();
-        boolean usePrimaryContinue = navigator.getCurrentPage() instanceof ScamScreenerPage;
+        boolean isScamScreenerPage = navigator.getCurrentPage() instanceof ScamScreenerPage;
 
         backButton.visible = hasBack;
         backButton.active = hasBack;
 
-        continueButton.visible = !isLastPage && !usePrimaryContinue;
-        continueButton.active = !isLastPage && !usePrimaryContinue;
+        continueButton.visible = !isLastPage && !isScamScreenerPage;
+        continueButton.active = !isLastPage && !isScamScreenerPage;
 
-        primaryContinueButton.visible = !isLastPage && usePrimaryContinue;
-        primaryContinueButton.active = !isLastPage && usePrimaryContinue;
+        scamScreenerContinueButton.visible = !isLastPage && isScamScreenerPage;
+        scamScreenerContinueButton.active = !isLastPage && isScamScreenerPage;
 
         skipButton.visible = isLastPage;
         skipButton.active = isLastPage;

--- a/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/WizardButtonBar.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/WizardButtonBar.java
@@ -4,6 +4,7 @@ import com.daqem.uilib.gui.component.EmptyComponent;
 import com.daqem.uilib.gui.widget.ButtonWidget;
 import com.daqem.uilib.gui.widget.CustomButtonWidget;
 import com.github.kd_gaming1.packcore.gui.util.GuiHelper;
+import com.github.kd_gaming1.packcore.gui.wizard.page.ScamScreenerPage;
 import com.github.kd_gaming1.packcore.metadata.ModpackMetadata;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.components.WidgetSprites;
@@ -31,6 +32,11 @@ public class WizardButtonBar extends EmptyComponent {
             Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/continue_gray_button"),
             Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/disabled_continue_gray_button"),
             Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/hover_continue_gray_button")
+    );
+    private static final WidgetSprites PRIMARY_CONTINUE_BUTTON = new WidgetSprites(
+            Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/blank_red_button"),
+            Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/disabled_red_button"),
+            Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/hover_red_button")
     );
 
     private static final WidgetSprites PREVIOUS_BUTTON = new WidgetSprites(
@@ -64,6 +70,7 @@ public class WizardButtonBar extends EmptyComponent {
     private final ButtonWidget backButton;
     private final ButtonWidget skipButton;
     private final ButtonWidget continueButton;
+    private final ButtonWidget primaryContinueButton;
     private final ButtonWidget finishButton;
 
     public WizardButtonBar(WizardNavigator navigator, int width, int height) {
@@ -99,6 +106,12 @@ public class WizardButtonBar extends EmptyComponent {
                 CONTINUE_BUTTON,
                 btn -> navigator.nextPage()
         );
+        primaryContinueButton = new CustomButtonWidget(
+                width - BTN_WIDTH - BTN_GAP, btnY, BTN_WIDTH, BTN_HEIGHT,
+                Component.translatable("gui.packcore.wizard.button.continue"),
+                PRIMARY_CONTINUE_BUTTON,
+                btn -> navigator.nextPage()
+        );
 
         backButton = new CustomButtonWidget(
                 width - BTN_WIDTH * 2 - BTN_GAP * 2, btnY, BTN_WIDTH, BTN_HEIGHT,
@@ -132,6 +145,7 @@ public class WizardButtonBar extends EmptyComponent {
         this.addWidget(skipButton);
         this.addWidget(backButton);
         this.addWidget(continueButton);
+        this.addWidget(primaryContinueButton);
         this.addWidget(finishButton);
 
         refresh();
@@ -141,12 +155,16 @@ public class WizardButtonBar extends EmptyComponent {
     public void refresh() {
         boolean hasBack = navigator.hasPrevious();
         boolean isLastPage = navigator.isOnLastPage();
+        boolean usePrimaryContinue = navigator.getCurrentPage() instanceof ScamScreenerPage;
 
         backButton.visible = hasBack;
         backButton.active = hasBack;
 
-        continueButton.visible = !isLastPage;
-        continueButton.active = !isLastPage;
+        continueButton.visible = !isLastPage && !usePrimaryContinue;
+        continueButton.active = !isLastPage && !usePrimaryContinue;
+
+        primaryContinueButton.visible = !isLastPage && usePrimaryContinue;
+        primaryContinueButton.active = !isLastPage && usePrimaryContinue;
 
         skipButton.visible = isLastPage;
         skipButton.active = isLastPage;

--- a/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/WizardState.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/WizardState.java
@@ -1,10 +1,16 @@
 package com.github.kd_gaming1.packcore.gui.wizard;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class WizardState {
 
     private final Map<String, String> selections = new HashMap<>();
+    private final Map<String, Set<String>> multiSelections = new HashMap<>();
     private final Set<String> selectedResourcePacks = new HashSet<>();
 
     // Selections
@@ -14,6 +20,25 @@ public class WizardState {
 
     public String getSelection(String key) {
         return selections.get(key);
+    }
+
+    // Generic multi-select state
+    public Set<String> getMultiSelection(String key) {
+        return Collections.unmodifiableSet(multiSelections.getOrDefault(key, Set.of()));
+    }
+
+    public void addMultiSelection(String key, String value) {
+        multiSelections.computeIfAbsent(key, ignored -> new LinkedHashSet<>()).add(value);
+    }
+
+    public void removeMultiSelection(String key, String value) {
+        Set<String> values = multiSelections.get(key);
+        if (values == null) return;
+
+        values.remove(value);
+        if (values.isEmpty()) {
+            multiSelections.remove(key);
+        }
     }
 
     // Resource Packs
@@ -33,6 +58,7 @@ public class WizardState {
     public String toString() {
         return "WizardState{" +
                 "selections=" + selections +
+                ", multiSelections=" + multiSelections +
                 ", resourcePacks=" + selectedResourcePacks +
                 '}';
     }

--- a/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/page/ConfirmApplyPage.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/page/ConfirmApplyPage.java
@@ -152,13 +152,20 @@ public class ConfirmApplyPage extends BaseWizardPage {
         // Build row container
         EmptyComponent rowContainer = new EmptyComponent(0, 0, rowWidth, 0);
         int currentY = 0;
+        boolean scamScreenerLoaded = FabricLoader.getInstance().isModLoaded("scamscreener");
 
         for (SummaryEntry entry : SUMMARY_ENTRIES) {
+            if (!scamScreenerLoaded && entry.selectionKey().equals(ScamScreenerPage.ALERT_LEVEL_KEY)) {
+                continue;
+            }
+
             String selectedId = state.getSelection(entry.selectionKey());
             boolean skipped = selectedId == null;
 
             Component valueText = skipped
                     ? Component.literal("Skipped")
+                    : entry.selectionKey().equals(ScamScreenerPage.ALERT_LEVEL_KEY)
+                    ? ScamScreenerPage.labelForAlertLevel(selectedId)
                     : Component.translatable(entry.translationPrefix() + selectedId + ".name");
             int valueColor = skipped ? COLOR_VALUE_SKIPPED : COLOR_VALUE_SELECTED;
 
@@ -171,33 +178,35 @@ public class ConfirmApplyPage extends BaseWizardPage {
             currentY += ROW_HEIGHT + ROW_GAP;
         }
 
-        Set<String> selectedPingOptions = state.getMultiSelection(ScamScreenerPage.PING_OPTIONS_KEY);
-        SummaryRowComponent pingHeaderRow = new SummaryRowComponent(
-                0, currentY, rowWidth, ROW_HEIGHT,
-                SCAM_SCREENER_PINGS_STATUS_KEY,
-                "ScamScreener Pings",
-                selectedPingOptions.isEmpty()
-                        ? Component.literal("None selected")
-                        : Component.literal(selectedPingOptions.size() + " selected"),
-                selectedPingOptions.isEmpty() ? COLOR_VALUE_SKIPPED : COLOR_VALUE_SELECTED,
-                false
-        );
-        scamPingRows.add(pingHeaderRow);
-        rowContainer.addComponent(pingHeaderRow);
-        currentY += ROW_HEIGHT + ROW_GAP;
-
-        for (String optionId : selectedPingOptions.stream().sorted(Comparator.naturalOrder()).toList()) {
-            SummaryRowComponent pingRow = new SummaryRowComponent(
+        if (scamScreenerLoaded) {
+            Set<String> selectedPingOptions = state.getMultiSelection(ScamScreenerPage.PING_OPTIONS_KEY);
+            SummaryRowComponent pingHeaderRow = new SummaryRowComponent(
                     0, currentY, rowWidth, ROW_HEIGHT,
                     SCAM_SCREENER_PINGS_STATUS_KEY,
-                    "",
-                    ScamScreenerPage.labelForPingOption(optionId),
-                    COLOR_PACK_NAME,
-                    true
+                    "ScamScreener Pings",
+                    selectedPingOptions.isEmpty()
+                            ? Component.literal("None selected")
+                            : Component.literal(selectedPingOptions.size() + " selected"),
+                    selectedPingOptions.isEmpty() ? COLOR_VALUE_SKIPPED : COLOR_VALUE_SELECTED,
+                    false
             );
-            scamPingRows.add(pingRow);
-            rowContainer.addComponent(pingRow);
+            scamPingRows.add(pingHeaderRow);
+            rowContainer.addComponent(pingHeaderRow);
             currentY += ROW_HEIGHT + ROW_GAP;
+
+            for (String optionId : selectedPingOptions.stream().sorted(Comparator.naturalOrder()).toList()) {
+                SummaryRowComponent pingRow = new SummaryRowComponent(
+                        0, currentY, rowWidth, ROW_HEIGHT,
+                        SCAM_SCREENER_PINGS_STATUS_KEY,
+                        "",
+                        ScamScreenerPage.labelForPingOption(optionId),
+                        COLOR_PACK_NAME,
+                        true
+                );
+                scamPingRows.add(pingRow);
+                rowContainer.addComponent(pingRow);
+                currentY += ROW_HEIGHT + ROW_GAP;
+            }
         }
 
         Set<String> selectedPacks = state.getSelectedResourcePacks();
@@ -270,11 +279,13 @@ public class ConfirmApplyPage extends BaseWizardPage {
         anyError |= runStep(StorageDesignPage.STATE_KEY,
                 () -> applyStorageDesign(state.getSelection(StorageDesignPage.STATE_KEY)));
 
-        anyError |= runStep(ScamScreenerPage.ALERT_LEVEL_KEY,
-                () -> applyScamScreener(
-                        state.getSelection(ScamScreenerPage.ALERT_LEVEL_KEY),
-                        state.getMultiSelection(ScamScreenerPage.PING_OPTIONS_KEY)
-                ));
+        if (FabricLoader.getInstance().isModLoaded("scamscreener")) {
+            anyError |= runStep(ScamScreenerPage.ALERT_LEVEL_KEY,
+                    () -> applyScamScreener(
+                            state.getSelection(ScamScreenerPage.ALERT_LEVEL_KEY),
+                            state.getMultiSelection(ScamScreenerPage.PING_OPTIONS_KEY)
+                    ));
+        }
 
         anyError |= runStep(RESOURCE_PACKS_KEY,
                 () -> applyResourcePacks(state.getSelectedResourcePacks()));
@@ -431,16 +442,13 @@ public class ConfirmApplyPage extends BaseWizardPage {
                 ? selectedId
                 : ScamScreenerConfigurator.defaultSettings().minimumRiskLevel();
 
-        ScamScreenerConfigurator.RuntimeSettings currentSettings = ScamScreenerConfigurator.loadSettings();
-
         boolean success = ScamScreenerConfigurator.apply(
                 minimumRiskLevel,
-                currentSettings.mutePatterns(),
                 pingOptions.contains("risk_warning"),
                 pingOptions.contains("blacklist_warning")
         );
         if (!success) {
-            throw new RuntimeException("Failed to update ScamScreener runtime.json");
+            throw new RuntimeException("Failed to update ScamScreener settings");
         }
     }
 

--- a/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/page/ConfirmApplyPage.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/page/ConfirmApplyPage.java
@@ -11,6 +11,7 @@ import com.github.kd_gaming1.packcore.gui.wizard.WizardState;
 import com.github.kd_gaming1.packcore.integration.ItemBackgroundManager;
 import com.github.kd_gaming1.packcore.integration.PerformanceProfileService;
 import com.github.kd_gaming1.packcore.integration.ResourcePackManager;
+import com.github.kd_gaming1.packcore.integration.ScamScreenerConfigurator;
 import com.github.kd_gaming1.packcore.integration.TabDesignManager;
 import com.github.kd_gaming1.packcore.integration.StorageDesignManager;
 import eu.midnightdust.lib.config.MidnightConfig;
@@ -24,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,17 +71,19 @@ public class ConfirmApplyPage extends BaseWizardPage {
             Identifier.fromNamespaceAndPath(MOD_ID, "menu/buttons/hover_blank_gray_button")
     );
 
-    private record SummaryEntry(String stateKey, String label, String translationPrefix) {}
+    private record SummaryEntry(String selectionKey, String statusKey, String label, String translationPrefix) {}
 
     private static final List<SummaryEntry> SUMMARY_ENTRIES = List.of(
-            new SummaryEntry(MainMenuDesignPage.STATE_KEY, "Main Menu Design",    "gui.packcore.wizard.menu_design."),
-            new SummaryEntry(PerformancePage.STATE_KEY,    "Performance Profile", "gui.packcore.wizard.performance."),
-            new SummaryEntry(TabDesignPage.STATE_KEY,      "Tab Design",          "gui.packcore.wizard.tab_design."),
-            new SummaryEntry(ItemBackgroundPage.STATE_KEY, "Item Background",     "gui.packcore.wizard.item_background."),
-            new SummaryEntry(StorageDesignPage.STATE_KEY,  "Storage Design",      "gui.packcore.wizard.storage_design.")
+            new SummaryEntry(MainMenuDesignPage.STATE_KEY, MainMenuDesignPage.STATE_KEY, "Main Menu Design", "gui.packcore.wizard.menu_design."),
+            new SummaryEntry(PerformancePage.STATE_KEY, PerformancePage.STATE_KEY, "Performance Profile", "gui.packcore.wizard.performance."),
+            new SummaryEntry(TabDesignPage.STATE_KEY, TabDesignPage.STATE_KEY, "Tab Design", "gui.packcore.wizard.tab_design."),
+            new SummaryEntry(ItemBackgroundPage.STATE_KEY, ItemBackgroundPage.STATE_KEY, "Item Background", "gui.packcore.wizard.item_background."),
+            new SummaryEntry(StorageDesignPage.STATE_KEY, StorageDesignPage.STATE_KEY, "Storage Design", "gui.packcore.wizard.storage_design."),
+            new SummaryEntry(ScamScreenerPage.ALERT_LEVEL_KEY, ScamScreenerPage.ALERT_LEVEL_KEY, "ScamScreener Alerts", "gui.packcore.wizard.scamscreener.minimum_risk.")
     );
 
     private static final String RESOURCE_PACKS_KEY = "resourcePacks";
+    private static final String SCAM_SCREENER_PINGS_STATUS_KEY = "scamScreenerPings";
 
     private enum RowStatus { SUCCESS, ERROR }
 
@@ -90,6 +94,7 @@ public class ConfirmApplyPage extends BaseWizardPage {
     // Hold references so we can push status updates into them after applying
     private final List<SummaryRowComponent> summaryRows = new ArrayList<>();
     private final List<SummaryRowComponent> packRows = new ArrayList<>();
+    private final List<SummaryRowComponent> scamPingRows = new ArrayList<>();
 
     private CustomButtonWidget applyButton = null;
     private String globalErrorMessage = null;
@@ -116,6 +121,7 @@ public class ConfirmApplyPage extends BaseWizardPage {
         rowErrors.clear();
         summaryRows.clear();
         packRows.clear();
+        scamPingRows.clear();
         globalErrorMessage = null;
 
         var font = Minecraft.getInstance().font;
@@ -148,7 +154,7 @@ public class ConfirmApplyPage extends BaseWizardPage {
         int currentY = 0;
 
         for (SummaryEntry entry : SUMMARY_ENTRIES) {
-            String selectedId = state.getSelection(entry.stateKey());
+            String selectedId = state.getSelection(entry.selectionKey());
             boolean skipped = selectedId == null;
 
             Component valueText = skipped
@@ -158,10 +164,39 @@ public class ConfirmApplyPage extends BaseWizardPage {
 
             SummaryRowComponent row = new SummaryRowComponent(
                     0, currentY, rowWidth, ROW_HEIGHT,
-                    entry.stateKey(), entry.label(), valueText, valueColor, false
+                    entry.statusKey(), entry.label(), valueText, valueColor, false
             );
             summaryRows.add(row);
             rowContainer.addComponent(row);
+            currentY += ROW_HEIGHT + ROW_GAP;
+        }
+
+        Set<String> selectedPingOptions = state.getMultiSelection(ScamScreenerPage.PING_OPTIONS_KEY);
+        SummaryRowComponent pingHeaderRow = new SummaryRowComponent(
+                0, currentY, rowWidth, ROW_HEIGHT,
+                SCAM_SCREENER_PINGS_STATUS_KEY,
+                "ScamScreener Pings",
+                selectedPingOptions.isEmpty()
+                        ? Component.literal("None selected")
+                        : Component.literal(selectedPingOptions.size() + " selected"),
+                selectedPingOptions.isEmpty() ? COLOR_VALUE_SKIPPED : COLOR_VALUE_SELECTED,
+                false
+        );
+        scamPingRows.add(pingHeaderRow);
+        rowContainer.addComponent(pingHeaderRow);
+        currentY += ROW_HEIGHT + ROW_GAP;
+
+        for (String optionId : selectedPingOptions.stream().sorted(Comparator.naturalOrder()).toList()) {
+            SummaryRowComponent pingRow = new SummaryRowComponent(
+                    0, currentY, rowWidth, ROW_HEIGHT,
+                    SCAM_SCREENER_PINGS_STATUS_KEY,
+                    "",
+                    ScamScreenerPage.labelForPingOption(optionId),
+                    COLOR_PACK_NAME,
+                    true
+            );
+            scamPingRows.add(pingRow);
+            rowContainer.addComponent(pingRow);
             currentY += ROW_HEIGHT + ROW_GAP;
         }
 
@@ -235,6 +270,12 @@ public class ConfirmApplyPage extends BaseWizardPage {
         anyError |= runStep(StorageDesignPage.STATE_KEY,
                 () -> applyStorageDesign(state.getSelection(StorageDesignPage.STATE_KEY)));
 
+        anyError |= runStep(ScamScreenerPage.ALERT_LEVEL_KEY,
+                () -> applyScamScreener(
+                        state.getSelection(ScamScreenerPage.ALERT_LEVEL_KEY),
+                        state.getMultiSelection(ScamScreenerPage.PING_OPTIONS_KEY)
+                ));
+
         anyError |= runStep(RESOURCE_PACKS_KEY,
                 () -> applyResourcePacks(state.getSelectedResourcePacks()));
 
@@ -271,6 +312,13 @@ public class ConfirmApplyPage extends BaseWizardPage {
         for (SummaryRowComponent row : summaryRows) {
             row.setStatus(rowStatuses.get(row.getKey()), rowErrors.get(row.getKey()));
         }
+
+        RowStatus scamPingStatus = rowStatuses.get(ScamScreenerPage.ALERT_LEVEL_KEY);
+        String scamPingError = rowErrors.get(ScamScreenerPage.ALERT_LEVEL_KEY);
+        for (SummaryRowComponent row : scamPingRows) {
+            row.setStatus(scamPingStatus, scamPingError);
+        }
+
         // All pack rows share the same status as the resource pack step
         RowStatus packStatus = rowStatuses.get(RESOURCE_PACKS_KEY);
         String packError = rowErrors.get(RESOURCE_PACKS_KEY);
@@ -370,6 +418,29 @@ public class ConfirmApplyPage extends BaseWizardPage {
         boolean success = StorageDesignManager.apply(design);
         if (!success) {
             throw new RuntimeException("Failed to apply storage design: " + selectedId);
+        }
+    }
+
+    private void applyScamScreener(String selectedId, Set<String> pingOptions) {
+        if (selectedId == null && pingOptions.isEmpty()) {
+            LOGGER.info("ScamScreener: skipped");
+            return;
+        }
+
+        String minimumRiskLevel = selectedId != null
+                ? selectedId
+                : ScamScreenerConfigurator.defaultSettings().minimumRiskLevel();
+
+        ScamScreenerConfigurator.RuntimeSettings currentSettings = ScamScreenerConfigurator.loadSettings();
+
+        boolean success = ScamScreenerConfigurator.apply(
+                minimumRiskLevel,
+                currentSettings.mutePatterns(),
+                pingOptions.contains("risk_warning"),
+                pingOptions.contains("blacklist_warning")
+        );
+        if (!success) {
+            throw new RuntimeException("Failed to update ScamScreener runtime.json");
         }
     }
 

--- a/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/page/ScamScreenerPage.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/page/ScamScreenerPage.java
@@ -1,0 +1,191 @@
+package com.github.kd_gaming1.packcore.gui.wizard.page;
+
+import com.daqem.uilib.gui.component.EmptyComponent;
+import com.daqem.uilib.gui.component.text.TextComponent;
+import com.daqem.uilib.gui.component.text.multiline.MultiLineTextComponent;
+import com.github.kd_gaming1.packcore.gui.component.MultiSelectList;
+import com.github.kd_gaming1.packcore.gui.component.OptionSelectList;
+import com.github.kd_gaming1.packcore.gui.wizard.BaseWizardPage;
+import com.github.kd_gaming1.packcore.gui.wizard.WizardNavigator;
+import com.github.kd_gaming1.packcore.gui.wizard.WizardState;
+import com.github.kd_gaming1.packcore.integration.ScamScreenerConfigurator;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+
+import java.util.List;
+
+public class ScamScreenerPage extends BaseWizardPage {
+
+    public static final String ALERT_LEVEL_KEY = "scamScreenerMinimumRiskLevel";
+    public static final String PING_OPTIONS_KEY = "scamScreenerPingOptions";
+
+    private static final Component PAGE_TITLE = Component.translatable("gui.packcore.wizard.page.scamscreener.title");
+
+    private static final int PADDING = 16;
+    private static final int COLUMN_GAP = 14;
+    private static final int SECTION_GAP = 10;
+    private static final int LABEL_GAP = 6;
+    private static final int COLOR_LABEL = 0xFFCCCCCC;
+    private static final int COLOR_HINT = 0xFF777777;
+
+    public ScamScreenerPage(WizardState state, WizardNavigator navigator, int width, int height) {
+        super(state, navigator, width, height);
+    }
+
+    @Override public Component getTitle() { return PAGE_TITLE; }
+    @Override public boolean validate() { return true; }
+    @Override public void onExit() {}
+
+    @Override
+    public void onEnter() {
+        this.clearComponents();
+        seedInitialState();
+
+        int availableWidth = getWidth() - PADDING * 2;
+        int availableHeight = getHeight() - PADDING * 2;
+
+        MultiLineTextComponent intro = new MultiLineTextComponent(
+                PADDING, PADDING, availableWidth,
+                Component.translatable("gui.packcore.wizard.page.scamscreener.explanation"),
+                COLOR_HINT
+        );
+        this.addComponent(intro);
+
+        int columnsY = PADDING + intro.getHeight() + SECTION_GAP;
+        int columnHeight = availableHeight - intro.getHeight() - SECTION_GAP;
+        int columnWidth = (availableWidth - COLUMN_GAP) / 2;
+
+        EmptyComponent leftColumn = new EmptyComponent(PADDING, columnsY, columnWidth, columnHeight);
+        EmptyComponent rightColumn = new EmptyComponent(PADDING + columnWidth + COLUMN_GAP, columnsY, columnWidth, columnHeight);
+
+        buildAlertLevelColumn(leftColumn, columnWidth, columnHeight);
+        buildPingColumn(rightColumn, columnWidth, columnHeight);
+
+        this.addComponent(leftColumn);
+        this.addComponent(rightColumn);
+    }
+
+    public static Component labelForPingOption(String optionId) {
+        return pingOptions().stream()
+                .filter(option -> option.id().equals(optionId))
+                .findFirst()
+                .map(PingOption::name)
+                .orElse(Component.literal(optionId));
+    }
+
+    private void seedInitialState() {
+        ScamScreenerConfigurator.RuntimeSettings settings = ScamScreenerConfigurator.loadSettings();
+
+        if (state.getSelection(ALERT_LEVEL_KEY) == null) {
+            state.setSelection(ALERT_LEVEL_KEY, settings.minimumRiskLevel());
+        }
+
+        if (state.getMultiSelection(PING_OPTIONS_KEY).isEmpty()) {
+            if (settings.pingOnRiskWarning()) {
+                state.addMultiSelection(PING_OPTIONS_KEY, "risk_warning");
+            }
+            if (settings.pingOnBlacklistWarning()) {
+                state.addMultiSelection(PING_OPTIONS_KEY, "blacklist_warning");
+            }
+        }
+    }
+
+    private void buildAlertLevelColumn(EmptyComponent column, int width, int height) {
+        var font = Minecraft.getInstance().font;
+
+        column.addComponent(new TextComponent(
+                0, 0,
+                Component.translatable("gui.packcore.wizard.scamscreener.alerts.heading"),
+                COLOR_LABEL
+        ));
+
+        int contentY = font.lineHeight + LABEL_GAP;
+        int contentHeight = height - contentY;
+
+        OptionSelectList<AlertLevelOption> list = new OptionSelectList<>(
+                0, contentY, width, contentHeight,
+                AlertLevelOption.all(),
+                OptionSelectList.RowDescriptor.of(
+                        AlertLevelOption::id,
+                        AlertLevelOption::name,
+                        AlertLevelOption::description
+                ),
+                state.getSelection(ALERT_LEVEL_KEY),
+                selected -> state.setSelection(ALERT_LEVEL_KEY, selected.id())
+        );
+        column.addComponent(list);
+    }
+
+    private void buildPingColumn(EmptyComponent column, int width, int height) {
+        var font = Minecraft.getInstance().font;
+        int currentY = 0;
+
+        column.addComponent(new TextComponent(
+                0, currentY,
+                Component.translatable("gui.packcore.wizard.scamscreener.pings.heading"),
+                COLOR_LABEL
+        ));
+        currentY += font.lineHeight + LABEL_GAP;
+
+        MultiLineTextComponent pingsHint = new MultiLineTextComponent(
+                0, currentY,
+                width,
+                Component.translatable("gui.packcore.wizard.scamscreener.pings.hint"),
+                COLOR_HINT
+        );
+        column.addComponent(pingsHint);
+        currentY += pingsHint.getHeight() + LABEL_GAP;
+
+        int pingListHeight = Math.max(100, height - currentY);
+        MultiSelectList<PingOption> pingList = new MultiSelectList<>(
+                0, currentY, width, pingListHeight,
+                pingOptions(),
+                MultiSelectList.RowDescriptor.of(
+                        PingOption::id,
+                        PingOption::name,
+                        PingOption::description
+                ),
+                state.getMultiSelection(PING_OPTIONS_KEY),
+                selected -> state.addMultiSelection(PING_OPTIONS_KEY, selected.id()),
+                deselected -> state.removeMultiSelection(PING_OPTIONS_KEY, deselected.id())
+        );
+        column.addComponent(pingList);
+    }
+
+    private static List<PingOption> pingOptions() {
+        return List.of(
+                new PingOption(
+                        "risk_warning",
+                        Component.translatable("gui.packcore.wizard.scamscreener.pings.risk.name"),
+                        Component.translatable("gui.packcore.wizard.scamscreener.pings.risk.desc")
+                ),
+                new PingOption(
+                        "blacklist_warning",
+                        Component.translatable("gui.packcore.wizard.scamscreener.pings.blacklist.name"),
+                        Component.translatable("gui.packcore.wizard.scamscreener.pings.blacklist.desc")
+                )
+        );
+    }
+
+    public record AlertLevelOption(String id, Component name, Component description) {
+        private static List<AlertLevelOption> all() {
+            return List.of(
+                    fromId("LOW"),
+                    fromId("MEDIUM"),
+                    fromId("HIGH"),
+                    fromId("CRITICAL")
+            );
+        }
+
+        private static AlertLevelOption fromId(String id) {
+            String baseKey = "gui.packcore.wizard.scamscreener.minimum_risk." + id;
+            return new AlertLevelOption(
+                    id,
+                    Component.translatable(baseKey + ".name"),
+                    Component.translatable(baseKey + ".desc")
+            );
+        }
+    }
+
+    public record PingOption(String id, Component name, Component description) {}
+}

--- a/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/page/ScamScreenerPage.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/gui/wizard/page/ScamScreenerPage.java
@@ -13,6 +13,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 
 import java.util.List;
+import java.util.Locale;
 
 public class ScamScreenerPage extends BaseWizardPage {
 
@@ -73,6 +74,10 @@ public class ScamScreenerPage extends BaseWizardPage {
                 .orElse(Component.literal(optionId));
     }
 
+    public static Component labelForAlertLevel(String optionId) {
+        return AlertLevelOption.fromId(optionId).name();
+    }
+
     private void seedInitialState() {
         ScamScreenerConfigurator.RuntimeSettings settings = ScamScreenerConfigurator.loadSettings();
 
@@ -92,6 +97,17 @@ public class ScamScreenerPage extends BaseWizardPage {
 
     private void buildAlertLevelColumn(EmptyComponent column, int width, int height) {
         var font = Minecraft.getInstance().font;
+        List<AlertLevelOption> alertLevels = ScamScreenerConfigurator.availableAlertLevels().stream()
+                .map(AlertLevelOption::fromId)
+                .toList();
+
+        String selectedAlertLevel = state.getSelection(ALERT_LEVEL_KEY);
+        String selectedAlertLevelCandidate = selectedAlertLevel;
+        boolean selectedValueExists = alertLevels.stream().anyMatch(option -> option.id().equals(selectedAlertLevelCandidate));
+        if (!selectedValueExists && !alertLevels.isEmpty()) {
+            selectedAlertLevel = alertLevels.getFirst().id();
+            state.setSelection(ALERT_LEVEL_KEY, selectedAlertLevel);
+        }
 
         column.addComponent(new TextComponent(
                 0, 0,
@@ -104,13 +120,13 @@ public class ScamScreenerPage extends BaseWizardPage {
 
         OptionSelectList<AlertLevelOption> list = new OptionSelectList<>(
                 0, contentY, width, contentHeight,
-                AlertLevelOption.all(),
+                alertLevels,
                 OptionSelectList.RowDescriptor.of(
                         AlertLevelOption::id,
                         AlertLevelOption::name,
                         AlertLevelOption::description
                 ),
-                state.getSelection(ALERT_LEVEL_KEY),
+                selectedAlertLevel,
                 selected -> state.setSelection(ALERT_LEVEL_KEY, selected.id())
         );
         column.addComponent(list);
@@ -168,22 +184,38 @@ public class ScamScreenerPage extends BaseWizardPage {
     }
 
     public record AlertLevelOption(String id, Component name, Component description) {
-        private static List<AlertLevelOption> all() {
-            return List.of(
-                    fromId("LOW"),
-                    fromId("MEDIUM"),
-                    fromId("HIGH"),
-                    fromId("CRITICAL")
+        private static AlertLevelOption fromId(String id) {
+            String normalizedId = id.toUpperCase(Locale.ROOT);
+            String baseKey = "gui.packcore.wizard.scamscreener.minimum_risk." + normalizedId;
+            return new AlertLevelOption(
+                    normalizedId,
+                    switch (normalizedId) {
+                        case "LOW", "MEDIUM", "HIGH", "CRITICAL" -> Component.translatable(baseKey + ".name");
+                        default -> Component.literal(prettyLabel(normalizedId));
+                    },
+                    switch (normalizedId) {
+                        case "LOW", "MEDIUM", "HIGH", "CRITICAL" -> Component.translatable(baseKey + ".desc");
+                        default -> Component.literal("Use ScamScreener's " + prettyLabel(normalizedId) + " warning threshold.");
+                    }
             );
         }
 
-        private static AlertLevelOption fromId(String id) {
-            String baseKey = "gui.packcore.wizard.scamscreener.minimum_risk." + id;
-            return new AlertLevelOption(
-                    id,
-                    Component.translatable(baseKey + ".name"),
-                    Component.translatable(baseKey + ".desc")
-            );
+        private static String prettyLabel(String id) {
+            String[] parts = id.split("_");
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < parts.length; i++) {
+                if (parts[i].isEmpty()) {
+                    continue;
+                }
+
+                if (builder.length() > 0) {
+                    builder.append(' ');
+                }
+
+                String part = parts[i].toLowerCase(Locale.ROOT);
+                builder.append(Character.toUpperCase(part.charAt(0))).append(part.substring(1));
+            }
+            return builder.toString();
         }
     }
 

--- a/src/main/java/com/github/kd_gaming1/packcore/integration/ScamScreenerApiBridge.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/integration/ScamScreenerApiBridge.java
@@ -1,0 +1,74 @@
+package com.github.kd_gaming1.packcore.integration;
+
+import eu.tango.scamscreener.api.ScamScreenerAlertLevel;
+import eu.tango.scamscreener.api.ScamScreenerApi;
+import eu.tango.scamscreener.api.ScamScreenerSettingsApi;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.util.Arrays;
+import java.util.List;
+
+final class ScamScreenerApiBridge {
+
+    private ScamScreenerApiBridge() {}
+
+    static boolean isAvailable() {
+        return !apis().isEmpty();
+    }
+
+    static ScamScreenerConfigurator.RuntimeSettings loadSettings() {
+        ScamScreenerSettingsApi settings = api().settings();
+        return new ScamScreenerConfigurator.RuntimeSettings(
+                settings.alertMinimumRiskLevel().name(),
+                settings.pingOnRiskWarning(),
+                settings.pingOnBlacklistWarning()
+        );
+    }
+
+    static List<String> availableAlertLevels() {
+        return Arrays.stream(ScamScreenerAlertLevel.values())
+                .map(Enum::name)
+                .toList();
+    }
+
+    static boolean apply(String minimumRiskLevel, boolean pingOnRiskWarning, boolean pingOnBlacklistWarning) {
+        ScamScreenerApi api = api();
+        ScamScreenerSettingsApi settings = api.settings();
+
+        ScamScreenerAlertLevel alertLevel = ScamScreenerAlertLevel.valueOf(minimumRiskLevel);
+        boolean changed = false;
+
+        if (settings.alertMinimumRiskLevel() != alertLevel) {
+            settings.setAlertMinimumRiskLevel(alertLevel);
+            changed = true;
+        }
+
+        if (settings.pingOnRiskWarning() != pingOnRiskWarning) {
+            settings.setPingOnRiskWarning(pingOnRiskWarning);
+            changed = true;
+        }
+
+        if (settings.pingOnBlacklistWarning() != pingOnBlacklistWarning) {
+            settings.setPingOnBlacklistWarning(pingOnBlacklistWarning);
+            changed = true;
+        }
+
+        if (changed) {
+            api.reload();
+        }
+
+        return true;
+    }
+
+    private static ScamScreenerApi api() {
+        List<ScamScreenerApi> apis = apis();
+        if (apis.isEmpty()) {
+            throw new IllegalStateException("ScamScreener API entrypoint not found");
+        }
+        return apis.getFirst();
+    }
+
+    private static List<ScamScreenerApi> apis() {
+        return FabricLoader.getInstance().getEntrypoints(ScamScreenerApi.ENTRYPOINT_KEY, ScamScreenerApi.class);
+    }
+}

--- a/src/main/java/com/github/kd_gaming1/packcore/integration/ScamScreenerConfigurator.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/integration/ScamScreenerConfigurator.java
@@ -1,0 +1,231 @@
+package com.github.kd_gaming1.packcore.integration;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import net.fabricmc.loader.api.FabricLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public final class ScamScreenerConfigurator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("PackCore/ScamScreenerConfigurator");
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private static final Path CONFIG_DIR = FabricLoader.getInstance().getConfigDir();
+    private static final Path PRIMARY_RUNTIME_PATH = CONFIG_DIR.resolve("scamscreener").resolve("runtime.json");
+    private static final Path LEGACY_RUNTIME_PATH = CONFIG_DIR.resolve("runtime.json");
+
+    private static final String DEFAULT_MINIMUM_RISK_LEVEL = "MEDIUM";
+    private static final boolean DEFAULT_PING_ON_RISK_WARNING = true;
+    private static final boolean DEFAULT_PING_ON_BLACKLIST_WARNING = true;
+    private static final List<String> DEFAULT_MUTE_PATTERNS = List.of();
+
+    private ScamScreenerConfigurator() {}
+
+    public record RuntimeSettings(
+            String minimumRiskLevel,
+            Set<String> mutePatterns,
+            boolean pingOnRiskWarning,
+            boolean pingOnBlacklistWarning
+    ) {}
+
+    public static RuntimeSettings loadSettings() {
+        Path path = resolveExistingPath();
+        if (path == null) {
+            return defaultSettings();
+        }
+
+        try (Reader reader = Files.newBufferedReader(path)) {
+            JsonObject root = JsonParser.parseReader(reader).getAsJsonObject();
+            return settingsFromJson(root);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to read ScamScreener runtime config '{}': {}", path, e.getMessage());
+            return defaultSettings();
+        }
+    }
+
+    public static RuntimeSettings defaultSettings() {
+        return new RuntimeSettings(
+                DEFAULT_MINIMUM_RISK_LEVEL,
+                new LinkedHashSet<>(DEFAULT_MUTE_PATTERNS),
+                DEFAULT_PING_ON_RISK_WARNING,
+                DEFAULT_PING_ON_BLACKLIST_WARNING
+        );
+    }
+
+    public static boolean apply(String minimumRiskLevel, Set<String> mutePatterns,
+                                boolean pingOnRiskWarning, boolean pingOnBlacklistWarning) {
+        Path targetPath = resolveWritePath();
+
+        try {
+            JsonObject root = loadOrCreateConfig(targetPath);
+            applySettings(root, minimumRiskLevel, mutePatterns, pingOnRiskWarning, pingOnBlacklistWarning);
+
+            Files.createDirectories(targetPath.getParent());
+            try (Writer writer = Files.newBufferedWriter(targetPath)) {
+                GSON.toJson(root, writer);
+            }
+
+            LOGGER.info("Updated ScamScreener runtime config at '{}'", targetPath);
+            return true;
+        } catch (IOException e) {
+            LOGGER.error("Failed to write ScamScreener runtime config: {}", e.getMessage(), e);
+            return false;
+        }
+    }
+
+    private static Path resolveExistingPath() {
+        if (Files.exists(PRIMARY_RUNTIME_PATH)) return PRIMARY_RUNTIME_PATH;
+        if (Files.exists(LEGACY_RUNTIME_PATH)) return LEGACY_RUNTIME_PATH;
+        return null;
+    }
+
+    private static Path resolveWritePath() {
+        Path existing = resolveExistingPath();
+        return existing != null ? existing : PRIMARY_RUNTIME_PATH;
+    }
+
+    private static JsonObject loadOrCreateConfig(Path targetPath) throws IOException {
+        if (!Files.exists(targetPath)) {
+            return createDefaultConfig();
+        }
+
+        try (Reader reader = Files.newBufferedReader(targetPath)) {
+            JsonElement parsed = JsonParser.parseReader(reader);
+            if (parsed != null && parsed.isJsonObject()) {
+                return parsed.getAsJsonObject();
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Existing ScamScreener config is invalid, recreating '{}': {}", targetPath, e.getMessage());
+        }
+
+        return createDefaultConfig();
+    }
+
+    private static RuntimeSettings settingsFromJson(JsonObject root) {
+        JsonObject alerts = getOrCreateObject(root, "alerts");
+        JsonObject safety = getOrCreateObject(root, "safety");
+        JsonObject output = getOrCreateObject(root, "output");
+
+        String minimumRiskLevel = getString(alerts, "minimumRiskLevel", DEFAULT_MINIMUM_RISK_LEVEL);
+        LinkedHashSet<String> mutePatterns = new LinkedHashSet<>();
+
+        if (safety.has("mutePatterns") && safety.get("mutePatterns").isJsonArray()) {
+            for (JsonElement element : safety.getAsJsonArray("mutePatterns")) {
+                if (element.isJsonPrimitive() && element.getAsJsonPrimitive().isString()) {
+                    mutePatterns.add(element.getAsString());
+                }
+            }
+        }
+
+        boolean pingOnRiskWarning = getBoolean(output, "pingOnRiskWarning", DEFAULT_PING_ON_RISK_WARNING);
+        boolean pingOnBlacklistWarning = getBoolean(output, "pingOnBlacklistWarning", DEFAULT_PING_ON_BLACKLIST_WARNING);
+
+        return new RuntimeSettings(minimumRiskLevel, mutePatterns, pingOnRiskWarning, pingOnBlacklistWarning);
+    }
+
+    private static void applySettings(JsonObject root, String minimumRiskLevel, Set<String> mutePatterns,
+                                      boolean pingOnRiskWarning, boolean pingOnBlacklistWarning) {
+        JsonObject alerts = getOrCreateObject(root, "alerts");
+        JsonObject safety = getOrCreateObject(root, "safety");
+        JsonObject output = getOrCreateObject(root, "output");
+
+        alerts.addProperty("minimumRiskLevel", minimumRiskLevel);
+
+        JsonArray mutePatternsJson = new JsonArray();
+        for (String pattern : mutePatterns) {
+            mutePatternsJson.add(pattern);
+        }
+
+        safety.addProperty("muteFilterEnabled", !mutePatterns.isEmpty());
+        safety.add("mutePatterns", mutePatternsJson);
+        output.addProperty("pingOnRiskWarning", pingOnRiskWarning);
+        output.addProperty("pingOnBlacklistWarning", pingOnBlacklistWarning);
+    }
+
+    private static JsonObject createDefaultConfig() {
+        JsonObject root = new JsonObject();
+        root.addProperty("version", 3);
+        root.addProperty("enabled", true);
+
+        JsonObject pipeline = new JsonObject();
+        pipeline.addProperty("reviewThreshold", 1);
+        root.add("pipeline", pipeline);
+
+        JsonObject alerts = new JsonObject();
+        alerts.addProperty("minimumRiskLevel", DEFAULT_MINIMUM_RISK_LEVEL);
+        alerts.addProperty("autoCaptureLevel", "MEDIUM");
+        root.add("alerts", alerts);
+
+        JsonObject output = new JsonObject();
+        output.addProperty("showRiskWarningMessage", true);
+        output.addProperty("pingOnRiskWarning", DEFAULT_PING_ON_RISK_WARNING);
+        output.addProperty("showBlacklistWarningMessage", true);
+        output.addProperty("pingOnBlacklistWarning", DEFAULT_PING_ON_BLACKLIST_WARNING);
+        output.addProperty("showAutoLeaveMessage", true);
+        output.addProperty("debugLogging", true);
+        root.add("output", output);
+
+        JsonObject review = new JsonObject();
+        review.addProperty("captureEnabled", true);
+        review.addProperty("maxEntries", 200);
+        root.add("review", review);
+
+        JsonObject safety = new JsonObject();
+        safety.addProperty("autoLeaveOnBlacklist", false);
+        safety.addProperty("muteFilterEnabled", false);
+        JsonArray mutePatterns = new JsonArray();
+        for (String pattern : DEFAULT_MUTE_PATTERNS) {
+            mutePatterns.add(pattern);
+        }
+        safety.add("mutePatterns", mutePatterns);
+        root.add("safety", safety);
+
+        JsonObject profiler = new JsonObject();
+        profiler.addProperty("hudEnabled", false);
+        root.add("profiler", profiler);
+
+        JsonObject debug = new JsonObject();
+        debug.add("flags", new JsonObject());
+        root.add("debug", debug);
+
+        return root;
+    }
+
+    private static JsonObject getOrCreateObject(JsonObject parent, String key) {
+        if (parent.has(key) && parent.get(key).isJsonObject()) {
+            return parent.getAsJsonObject(key);
+        }
+
+        JsonObject child = new JsonObject();
+        parent.add(key, child);
+        return child;
+    }
+
+    private static String getString(JsonObject json, String key, String fallback) {
+        if (json.has(key) && json.get(key).isJsonPrimitive() && json.get(key).getAsJsonPrimitive().isString()) {
+            return json.get(key).getAsString();
+        }
+        return fallback;
+    }
+
+    private static boolean getBoolean(JsonObject json, String key, boolean fallback) {
+        if (json.has(key) && json.get(key).isJsonPrimitive() && json.get(key).getAsJsonPrimitive().isBoolean()) {
+            return json.get(key).getAsBoolean();
+        }
+        return fallback;
+    }
+}

--- a/src/main/java/com/github/kd_gaming1/packcore/integration/ScamScreenerConfigurator.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/integration/ScamScreenerConfigurator.java
@@ -15,9 +15,7 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 public final class ScamScreenerConfigurator {
 
@@ -31,18 +29,46 @@ public final class ScamScreenerConfigurator {
     private static final String DEFAULT_MINIMUM_RISK_LEVEL = "MEDIUM";
     private static final boolean DEFAULT_PING_ON_RISK_WARNING = true;
     private static final boolean DEFAULT_PING_ON_BLACKLIST_WARNING = true;
+    private static final List<String> DEFAULT_ALERT_LEVELS = List.of("LOW", "MEDIUM", "HIGH", "CRITICAL");
     private static final List<String> DEFAULT_MUTE_PATTERNS = List.of();
 
     private ScamScreenerConfigurator() {}
 
     public record RuntimeSettings(
             String minimumRiskLevel,
-            Set<String> mutePatterns,
             boolean pingOnRiskWarning,
             boolean pingOnBlacklistWarning
     ) {}
 
     public static RuntimeSettings loadSettings() {
+        if (FabricLoader.getInstance().isModLoaded("scamscreener")) {
+            try {
+                if (ScamScreenerApiBridge.isAvailable()) {
+                    return ScamScreenerApiBridge.loadSettings();
+                }
+            } catch (RuntimeException | LinkageError e) {
+                LOGGER.warn("Failed to load ScamScreener settings from API, falling back to runtime.json: {}", e.getMessage());
+            }
+        }
+
+        return loadSettingsFromJson();
+    }
+
+    public static List<String> availableAlertLevels() {
+        if (FabricLoader.getInstance().isModLoaded("scamscreener")) {
+            try {
+                if (ScamScreenerApiBridge.isAvailable()) {
+                    return ScamScreenerApiBridge.availableAlertLevels();
+                }
+            } catch (RuntimeException | LinkageError e) {
+                LOGGER.warn("Failed to read ScamScreener alert levels from API, falling back to defaults: {}", e.getMessage());
+            }
+        }
+
+        return DEFAULT_ALERT_LEVELS;
+    }
+
+    private static RuntimeSettings loadSettingsFromJson() {
         Path path = resolveExistingPath();
         if (path == null) {
             return defaultSettings();
@@ -60,19 +86,31 @@ public final class ScamScreenerConfigurator {
     public static RuntimeSettings defaultSettings() {
         return new RuntimeSettings(
                 DEFAULT_MINIMUM_RISK_LEVEL,
-                new LinkedHashSet<>(DEFAULT_MUTE_PATTERNS),
                 DEFAULT_PING_ON_RISK_WARNING,
                 DEFAULT_PING_ON_BLACKLIST_WARNING
         );
     }
 
-    public static boolean apply(String minimumRiskLevel, Set<String> mutePatterns,
-                                boolean pingOnRiskWarning, boolean pingOnBlacklistWarning) {
+    public static boolean apply(String minimumRiskLevel, boolean pingOnRiskWarning, boolean pingOnBlacklistWarning) {
+        if (FabricLoader.getInstance().isModLoaded("scamscreener")) {
+            try {
+                if (ScamScreenerApiBridge.isAvailable()) {
+                    return ScamScreenerApiBridge.apply(minimumRiskLevel, pingOnRiskWarning, pingOnBlacklistWarning);
+                }
+            } catch (RuntimeException | LinkageError e) {
+                LOGGER.warn("Failed to apply ScamScreener settings through API, falling back to runtime.json: {}", e.getMessage());
+            }
+        }
+
+        return applyViaJson(minimumRiskLevel, pingOnRiskWarning, pingOnBlacklistWarning);
+    }
+
+    private static boolean applyViaJson(String minimumRiskLevel, boolean pingOnRiskWarning, boolean pingOnBlacklistWarning) {
         Path targetPath = resolveWritePath();
 
         try {
             JsonObject root = loadOrCreateConfig(targetPath);
-            applySettings(root, minimumRiskLevel, mutePatterns, pingOnRiskWarning, pingOnBlacklistWarning);
+            applySettings(root, minimumRiskLevel, readMutePatterns(root), pingOnRiskWarning, pingOnBlacklistWarning);
 
             Files.createDirectories(targetPath.getParent());
             try (Writer writer = Files.newBufferedWriter(targetPath)) {
@@ -117,27 +155,29 @@ public final class ScamScreenerConfigurator {
 
     private static RuntimeSettings settingsFromJson(JsonObject root) {
         JsonObject alerts = getOrCreateObject(root, "alerts");
-        JsonObject safety = getOrCreateObject(root, "safety");
         JsonObject output = getOrCreateObject(root, "output");
 
         String minimumRiskLevel = getString(alerts, "minimumRiskLevel", DEFAULT_MINIMUM_RISK_LEVEL);
-        LinkedHashSet<String> mutePatterns = new LinkedHashSet<>();
-
-        if (safety.has("mutePatterns") && safety.get("mutePatterns").isJsonArray()) {
-            for (JsonElement element : safety.getAsJsonArray("mutePatterns")) {
-                if (element.isJsonPrimitive() && element.getAsJsonPrimitive().isString()) {
-                    mutePatterns.add(element.getAsString());
-                }
-            }
-        }
-
         boolean pingOnRiskWarning = getBoolean(output, "pingOnRiskWarning", DEFAULT_PING_ON_RISK_WARNING);
         boolean pingOnBlacklistWarning = getBoolean(output, "pingOnBlacklistWarning", DEFAULT_PING_ON_BLACKLIST_WARNING);
 
-        return new RuntimeSettings(minimumRiskLevel, mutePatterns, pingOnRiskWarning, pingOnBlacklistWarning);
+        return new RuntimeSettings(minimumRiskLevel, pingOnRiskWarning, pingOnBlacklistWarning);
     }
 
-    private static void applySettings(JsonObject root, String minimumRiskLevel, Set<String> mutePatterns,
+    private static List<String> readMutePatterns(JsonObject root) {
+        JsonObject safety = getOrCreateObject(root, "safety");
+        if (!safety.has("mutePatterns") || !safety.get("mutePatterns").isJsonArray()) {
+            return DEFAULT_MUTE_PATTERNS;
+        }
+
+        return safety.getAsJsonArray("mutePatterns").asList().stream()
+                .filter(JsonElement::isJsonPrimitive)
+                .filter(element -> element.getAsJsonPrimitive().isString())
+                .map(JsonElement::getAsString)
+                .toList();
+    }
+
+    private static void applySettings(JsonObject root, String minimumRiskLevel, List<String> mutePatterns,
                                       boolean pingOnRiskWarning, boolean pingOnBlacklistWarning) {
         JsonObject alerts = getOrCreateObject(root, "alerts");
         JsonObject safety = getOrCreateObject(root, "safety");

--- a/src/main/resources/assets/packcore/lang/en_us.json
+++ b/src/main/resources/assets/packcore/lang/en_us.json
@@ -112,6 +112,26 @@
   "gui.packcore.wizard.storage_design.vanilla.name": "Vanilla",
   "gui.packcore.wizard.storage_design.vanilla.desc": "Default chest appearance with tooltips that show each page's contents on hover.",
 
+  "gui.packcore.wizard.page.scamscreener.title": "ScamScreener",
+  "gui.packcore.wizard.page.scamscreener.explanation": "Configure how aggressively ScamScreener should warn and whether warning messages should ping you in chat.",
+  "gui.packcore.wizard.scamscreener.alerts.heading": "Minimum Alert Level",
+  "gui.packcore.wizard.scamscreener.pings.heading": "Warning Pings",
+  "gui.packcore.wizard.scamscreener.pings.hint": "Choose which ScamScreener warning types should play a ping in chat.",
+
+  "gui.packcore.wizard.scamscreener.minimum_risk.LOW.name": "Low",
+  "gui.packcore.wizard.scamscreener.minimum_risk.LOW.desc": "Show all ScamScreener warnings, including low-confidence alerts. ⚠ Higher chance of false positives!",
+  "gui.packcore.wizard.scamscreener.minimum_risk.MEDIUM.name": "Medium (Recommended)",
+  "gui.packcore.wizard.scamscreener.minimum_risk.MEDIUM.desc": "Hide low-confidence alerts and only warn when risk is medium or higher. Best default for most players.",
+  "gui.packcore.wizard.scamscreener.minimum_risk.HIGH.name": "High",
+  "gui.packcore.wizard.scamscreener.minimum_risk.HIGH.desc": "Only surface stronger warnings with a lower chance of false positives.",
+  "gui.packcore.wizard.scamscreener.minimum_risk.CRITICAL.name": "Critical",
+  "gui.packcore.wizard.scamscreener.minimum_risk.CRITICAL.desc": "Only show the most severe warnings.",
+
+  "gui.packcore.wizard.scamscreener.pings.risk.name": "Ping On Risk Warning",
+  "gui.packcore.wizard.scamscreener.pings.risk.desc": "Enable the chat ping when ScamScreener raises a normal risk warning.",
+  "gui.packcore.wizard.scamscreener.pings.blacklist.name": "Ping On Blacklist Warning",
+  "gui.packcore.wizard.scamscreener.pings.blacklist.desc": "Enable the chat ping when ScamScreener detects a blacklist warning.",
+
   "gui.packcore.wizard.page.resource_pack.title": "Resource Packs",
   "gui.packcore.wizard.resource_pack.none_found": "No resource packs were found in your resource packs folder. Add resource packs there and reopen the wizard.",
   "gui.packcore.wizard.resource_pack.no_description": "No description provided.",

--- a/src/main/resources/assets/packcore/lang/en_us.json
+++ b/src/main/resources/assets/packcore/lang/en_us.json
@@ -37,6 +37,8 @@
 
   "gui.packcore.overlay.changelog.title": "Changelog — v%s",
   "gui.packcore.overlay.changelog.close": "Close",
+  "gui.packcore.overlay.changelog.empty": "No changelog available.",
+  "gui.packcore.overlay.changelog.empty.hint": "PackCore could not load changelog text for this version.",
 
   "gui.packcore.wizard.title": "Welcome to v%s",
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,5 +24,8 @@
   "depends": {
     "fabricloader": ">=${fabricloader}",
     "minecraft": "${minecraft}"
+  },
+  "suggests": {
+    "scamscreener": "*"
   }
 }

--- a/versions/1.21.11/gradle.properties
+++ b/versions/1.21.11/gradle.properties
@@ -4,6 +4,7 @@ deps.midnightlib_version=1.9.2+1.21.11-fabric
 deps.hm_api_version=1.0.1+1.21.2
 deps.modmenu_version=17.0.0-beta.2
 deps.uilib_version=19.1.0
+deps.scamscreener_version=uue2ayyA
 
 deps.sodium_version=mc1.21.11-0.8.4-fabric
 deps.iris_version=1.10.5+1.21.11-fabric


### PR DESCRIPTION
# Summary
This PR integrates ScamScreener into the welcome wizard through its published API. And fixes the background image not saved properly.

## Whats Changed
- Added an optional ScamScreener integration to PackCore
- Applied wizard selections through the API for:
  - Minimum Alert Risk Level
  - Ping On Risk Warning
  - Ping On Blacklist Warning

- Made the available alert levels dynamic so the wizard stays compatible with future ScamScreener changes
- Only show the ScamScreener wizard step when ScamScreener is actually installed


## Fixes

- Fixed the post-wizard flow so PackCore opens the newly selected title screen immediately after finishing setup
- Fixed a startup crash caused by a missing changelog string in the title screen overlay


> ScamScreener can evolve independently from PackCore. Reading available settings from the API avoids config drift and makes the wizard more robust across ScamScreener updates.


## Testing
- [x] `./gradlew build`
- [x] Wizard Test

## Note
Could not test other features of wizard. didn't know what else i need to test it. most of the time it showed some placeholders.
-> See Pictures

---

<img width="1898" height="993" alt="image" src="https://github.com/user-attachments/assets/80783f4a-c1c9-464d-8df9-83698d087a8f" />

<img width="1775" height="585" alt="image" src="https://github.com/user-attachments/assets/d7b79ed8-6f68-498b-95c1-66605d114794" />

---

<img width="1912" height="1001" alt="image" src="https://github.com/user-attachments/assets/cd7b7b25-5ce6-437c-89b8-2893a27164cb" />

<img width="1907" height="997" alt="image" src="https://github.com/user-attachments/assets/61c75717-682f-47f2-aad5-6ad9a04bae1f" />

<img width="1902" height="1000" alt="image" src="https://github.com/user-attachments/assets/f45e846d-0085-4f7e-8541-9fe763b8bd10" />

<img width="1713" height="138" alt="image" src="https://github.com/user-attachments/assets/3519dcda-20d6-4639-8b60-5d9a9bee18f1" />
<img width="1713" height="139" alt="image" src="https://github.com/user-attachments/assets/9751fbae-857e-4cba-a8de-b88008f596f0" />
<img width="1708" height="133" alt="image" src="https://github.com/user-attachments/assets/1cf24fef-006f-448e-b5f1-5ce943055dc6" />
<img width="1602" height="213" alt="image" src="https://github.com/user-attachments/assets/8f509e68-13d3-4c62-83f4-bd95d00ac98c" />
