### PR TITLE
fix: made Custom Titlescreen more robust against freezing

### DIFF
--- a/src/main/java/com/github/kd_gaming1/packcore/PackCore.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/PackCore.java
@@ -27,6 +27,7 @@ public class PackCore implements ClientModInitializer {
     public static final Path PACKCORE_DIR = FabricLoader.getInstance().getGameDir().resolve("packcore");
 
     public static boolean migratedFromV3 = false;
+    private static boolean replacingTitleScreen = false;
 
     @Override
     public void onInitializeClient() {
@@ -39,7 +40,7 @@ public class PackCore implements ClientModInitializer {
         ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> PackCoreCommands.register(dispatcher));
 
         ScreenEvents.BEFORE_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
-            if (!(screen instanceof TitleScreen) || screen instanceof PackCoreTitleScreen) return;
+            if (!(screen instanceof TitleScreen) || screen instanceof PackCoreTitleScreen || replacingTitleScreen) return;
 
             RamWarningHelper.onMainMenu();
 
@@ -48,11 +49,18 @@ public class PackCore implements ClientModInitializer {
                 return;
             }
 
-            switch (PackCoreConfig.menuStyle) {
-                case MODERN         -> client.execute(() -> client.setScreen(new SBETitleScreen()));
-                case MODERN_MINIMAL -> client.execute(() -> client.setScreen(new SBETitleScreen(false)));
-                case MINIMAL        -> client.execute(() -> client.setScreen(new PackCoreTitleScreen()));
-            }
+            client.execute(() -> {
+                replacingTitleScreen = true;
+                try {
+                    switch (PackCoreConfig.menuStyle) {
+                        case MODERN -> client.setScreen(new SBETitleScreen());
+                        case MODERN_MINIMAL -> client.setScreen(new SBETitleScreen(false));
+                        case MINIMAL -> client.setScreen(new PackCoreTitleScreen());
+                    }
+                } finally {
+                    replacingTitleScreen = false;
+                }
+            });
         });
 
         ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> client.execute(RamWarningHelper::onWorldJoin));

--- a/src/main/java/com/github/kd_gaming1/packcore/PackCorePreLaunch.java
+++ b/src/main/java/com/github/kd_gaming1/packcore/PackCorePreLaunch.java
@@ -26,17 +26,16 @@ import java.util.Optional;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import static com.github.kd_gaming1.packcore.PackCore.MOD_ID;
-
 public class PackCorePreLaunch implements PreLaunchEntrypoint {
 
+    private static final String MOD_ID = "packcore";
     private static final Logger LOGGER = LoggerFactory.getLogger("PackCore/PreLaunch");
     private static final String PACK_META_FILE = "pack.json";
 
     @Override
     public void onPreLaunch() {
         Path gameDir = FabricLoader.getInstance().getGameDir();
-        Path packcoreDir = PackCore.PACKCORE_DIR;
+        Path packcoreDir = gameDir.resolve(MOD_ID);
         Path configsDir = packcoreDir.resolve("configs");
 
         MidnightConfig.init("packcore", PackCoreConfig.class);


### PR DESCRIPTION
# PR Description

## Summary

This change fixes the title screen replacement loop without changing the normal PackCore startup flow.

It also removes an unnecessary `preLaunch` dependency on the `PackCore` client initializer so `preLaunch` no longer pulls client-side classes in earlier than needed.

## What changed

### 1. Guard the title screen replacement path

In [PackCore.java](/C:/Users/mine6/Documents/GitHub/PackCore/src/main/java/com/github/kd_gaming1/packcore/PackCore.java), the `ScreenEvents.BEFORE_INIT` hook now bails out when:

- the screen is not a `TitleScreen`
- the screen is already a `PackCoreTitleScreen`
- PackCore is already in the middle of replacing the title screen

The welcome wizard behavior stays the same:

- if `successfulWelcomeWizard` is `false`, PackCore opens `WelcomeWizardScreen`
- otherwise, PackCore opens the configured custom main menu

### 2. Decouple `preLaunch` from `PackCore`

In [PackCorePreLaunch.java](/C:/Users/mine6/Documents/GitHub/PackCore/src/main/java/com/github/kd_gaming1/packcore/PackCorePreLaunch.java), `packcoreDir` is now built from `gameDir.resolve("packcore")` instead of reading `PackCore.PACKCORE_DIR`.

## Why this works

### Title screen loop

`PackCoreTitleScreen` extends `TitleScreen`. That means the global `BEFORE_INIT` hook also sees PackCore's own replacement screen unless it is explicitly excluded.

Without a guard, this flow can happen:

1. Vanilla `TitleScreen` initializes
2. PackCore replaces it with `PackCoreTitleScreen`
3. `PackCoreTitleScreen` initializes
4. The same hook runs again because it is still a `TitleScreen`
5. PackCore replaces it again

That creates a re-entry loop.

The fix works because PackCore now stops once it is already handling its own replacement path. Vanilla `TitleScreen` is still redirected, but PackCore's own title screen is not redirected again.

### `preLaunch` safety

`preLaunch` only needs the PackCore config directory path. It does not need the full `PackCore` client initializer.

By computing the path locally instead of touching `PackCore.PACKCORE_DIR`, `PackCorePreLaunch` no longer forces `PackCore` to load during the `preLaunch` stage. That keeps early startup simpler and avoids loading unrelated client classes before the normal client entrypoint runs.

## Behavior impact

- The welcome wizard still opens when `successfulWelcomeWizard` is `false`
- The configured PackCore main menu still replaces the vanilla title screen
- PackCore no longer reprocesses its own title screen and loop on init
- `preLaunch` still reads and applies config packs exactly as before

## Verification

- `.\gradlew.bat compileJava`
